### PR TITLE
Make the infra outputs more flexible

### DIFF
--- a/producers/infra-producer/handler/outputs.go
+++ b/producers/infra-producer/handler/outputs.go
@@ -1,39 +1,71 @@
 package handler
 
 import (
+	"fmt"
 	"github.com/Microsoft/kunlun/common/helpers"
+	"strings"
 )
 
 type Outputs interface {
+	Keys() []string
 	GetString(key string) string
 	GetStringSlice(key string) []string
 	GetStringMap(key string) map[string]string
 }
 
-var outputsOpsFile = []byte(`
----
+var outputIpTemplate = []byte(`
 - type: replace
-  path: /vm_groups/name=jumpbox/networks/0/outputs?
+  path: /vm_groups/name={{.vm_group_name}}/networks/0/outputs?
   value:
-    - public_ip: {{.vm_groups_jumpbox_networks_0_outputs_0}}
-- type: replace
-  path: /vm_groups/name=web-servers/networks/0/outputs?
-  value:
-    - ip: {{.vm_groups_web_servers_networks_0_outputs_0}}
+    - ip: {{.ip}}
 `)
-
-func ToOutputsOpsFile(outputs Outputs) (string, error) {
-	contents, err := helpers.Render(outputsOpsFile, getOutputsParams(outputs))
-	if err != nil {
-		return "", err
-	}
-
-	return contents, nil
+var outputPublicIpTemplate = []byte(`
+- type: replace
+  path: /vm_groups/name={{.vm_group_name}}/networks/0/outputs?/0/public_ip?
+  value: {{.public_ip}}
+`)
+var outputHostTemplate = []byte(`
+- type: replace
+  path: /vm_groups/name={{.vm_group_name}}/networks/0/outputs?/0/host?
+  value: {{.host}}
+`)
+var outputOptionalTemplates = map[string][]byte{
+	"public_ip": outputPublicIpTemplate,
+	"host":      outputHostTemplate,
 }
 
-func getOutputsParams(outputs Outputs) map[string]interface{} {
-	return map[string]interface{}{
-		"vm_groups_jumpbox_networks_0_outputs_0":     outputs.GetStringMap("vm_groups_jumpbox_networks_0_outputs_0")["public_ip"],
-		"vm_groups_web_servers_networks_0_outputs_0": outputs.GetStringMap("vm_groups_web-servers_networks_0_outputs_0")["ip"],
+func ToOutputsOpsFile(outputs Outputs) (string, error) {
+	vm_group_outputs := ""
+	for _, key := range outputs.Keys() {
+		if strings.HasPrefix(key, "vm_groups") {
+			vm_group_name := strings.Split(key, "_")[2]
+			template, params := getTemplateAndParams(vm_group_name, outputs)
+			vm_group_output, err := helpers.Render(template, params)
+			if err != nil {
+				return "", err
+			}
+			vm_group_outputs += vm_group_output
+		}
 	}
+	return vm_group_outputs, nil
+}
+
+func getTemplateAndParams(vm_group_name string, outputs Outputs) ([]byte, map[string]interface{}) {
+	output := outputs.GetStringMap(fmt.Sprintf("vm_groups_%s_networks_0_outputs_0", vm_group_name))
+
+	template := make([]byte, 0)
+	params := make(map[string]interface{})
+	params["vm_group_name"] = vm_group_name
+	// We assume that the internal IP address always exists
+	template = append(template, outputIpTemplate...)
+	params["ip"] = output["ip"]
+	// public_ip and host are optional
+	param_keys := []string{"public_ip", "host"}
+	for _, param_key := range param_keys {
+		if value, ok := output[param_key]; ok {
+			template = append(template, outputOptionalTemplates[param_key]...)
+			params[param_key] = value
+		}
+	}
+	return template, params
 }

--- a/producers/infra-producer/tfhandler/terraform/outputs.go
+++ b/producers/infra-producer/tfhandler/terraform/outputs.go
@@ -4,6 +4,14 @@ type Outputs struct {
 	Map map[string]interface{}
 }
 
+func (o Outputs) Keys() []string {
+	keys := make([]string, len(o.Map))
+	for key, _ := range o.Map {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
 func (o Outputs) GetString(key string) string {
 	if val, ok := o.Map[key]; ok {
 		if s, ok := val.(string); ok {


### PR DESCRIPTION
Instead of hardcoding "jumpbox" and "web-server", the infra-producer will
get the outputs (ip, public_ip, host) of all VM groups.

Fixes #9 

