### PR TITLE
Support configuring domain name of the load balancer

### DIFF
--- a/artifacts/load_balancer.go
+++ b/artifacts/load_balancer.go
@@ -4,6 +4,7 @@ package artifacts
 type LoadBalancer struct {
 	Name                string                           `yaml:"name"`
 	SKU                 string                           `yaml:"sku"`
+	DomainName          string                           `yaml:"domain_name,omitempty"`
 	BackendAddressPools []LoadBalancerBackendAddressPool `yaml:"backend_address_pools"`
 	HealthProbes        []LoadBalancerHealthProbe        `yaml:"health_probes"`
 	Rules               []LoadBalancerRule               `yaml:"rules"`

--- a/producers/infra-producer/tfhandler/terraform/templates/load_balancer.go
+++ b/producers/infra-producer/tfhandler/terraform/templates/load_balancer.go
@@ -13,7 +13,7 @@ resource "azurerm_public_ip" "{{.lbName}}_public_ip" {
 	public_ip_address_allocation = "static"
 	sku                          = "${var.{{.lbName}}_al_sku}"
 	{{if .haveDomainName -}}
-	domain_name_label = "{{var.{{.lbName}}_al_domain_name_label}}"
+	domain_name_label = "${var.{{.lbName}}_al_domain_name_label}"
 	{{- end}}
 }
 

--- a/producers/infra-producer/tfhandler/terraform/templates/load_balancer.go
+++ b/producers/infra-producer/tfhandler/terraform/templates/load_balancer.go
@@ -12,6 +12,9 @@ resource "azurerm_public_ip" "{{.lbName}}_public_ip" {
 	resource_group_name          = "${azurerm_resource_group.kunlun_resource_group.name}"
 	public_ip_address_allocation = "static"
 	sku                          = "${var.{{.lbName}}_al_sku}"
+	{{if .haveDomainName -}}
+	domain_name_label = "{{var.{{.lbName}}_al_domain_name_label}}"
+	{{- end}}
 }
 
 resource "azurerm_lb" "{{.lbName}}" {
@@ -26,10 +29,16 @@ resource "azurerm_lb" "{{.lbName}}" {
   }
 
 variable "{{.lbName}}_al_sku" {}
+{{if .haveDomainName -}}
+variable "{{.lbName}}_al_domain_name_label" {}
+{{- end}}
 `)
 
 var loadBalancerTFVars = []byte(`
 {{.lbName}}_al_sku = "{{.al_sku}}"
+{{if .haveDomainName -}}
+{{.lbName}}_al_domain_name_label = "{{.al_domain_name_label}}"
+{{- end}}
 `)
 
 var loadBalancerBackendAddressPoolTF = []byte(`
@@ -170,14 +179,17 @@ func NewLoadBalancerInput(lb artifacts.LoadBalancer) (string, error) {
 
 func getLoadBalancerTFParams(lb artifacts.LoadBalancer) map[string]interface{} {
 	return map[string]interface{}{
-		"lbName": lb.Name,
+		"lbName":         lb.Name,
+		"haveDomainName": lb.DomainName != "",
 	}
 }
 
 func getLoadBalancerTFVarsParams(lb artifacts.LoadBalancer) map[string]interface{} {
 	return map[string]interface{}{
-		"lbName": lb.Name,
-		"al_sku": lb.SKU,
+		"lbName":               lb.Name,
+		"al_sku":               lb.SKU,
+		"haveDomainName":       lb.DomainName != "",
+		"al_domain_name_label": lb.DomainName,
 	}
 }
 


### PR DESCRIPTION
Solve (a part of?) #36 .
Support config domain name of the load balancer. Users can config the domain name by setting `domain_name` in the load balancer field in the manifest. An example:
```yaml
load_balancers:
  - name: load_balancer_1
    sku: Standard
    backend_address_pools:
      - name: backend_address_pool_1
    domain_name: tositestdomain             ###############NOTE HERE###################
    health_probes:
      - name: http_probe
        protocol: Tcp # optional values: [Tcp, Http, Https]
        port: 80
        # request_path: "/" # required if protocol is set to Http or Https. Otherwise, it is not allowed.
      - name: ssh_probe
        protocol: Tcp
        port: 22
    rules:
      - name: http_rule
        protocol: Tcp # optional values: [Tcp, Udp, All]
        frontend_port: 80
        backend_port: 80
        backend_address_pool_name: backend_address_pool_1
        health_probe_name: http_probe

```
However, I'm not very clear about when to edit this field in our workflow. Obviously, we can't give a default value in buildinmanifests, since domain name should be unique across an Azure region. Maybe we should also generate a patch file and remind the user to fill in the patch file?
Feel free to contact me at any time.

CC: @andyliuliming 